### PR TITLE
Rename local @markup variable to stop it hiding the scope of the parent ...

### DIFF
--- a/image_tag.rb
+++ b/image_tag.rb
@@ -31,12 +31,12 @@ module Jekyll
     def render(context)
 
       # Render any liquid variables in tag arguments and unescape template code
-      @markup = Liquid::Template.parse(@markup).render(context).gsub(/\\\{\\\{|\\\{\\%/, '\{\{' => '{{', '\{\%' => '{%')
+      @instancemarkup = Liquid::Template.parse(@markup).render(context).gsub(/\\\{\\\{|\\\{\\%/, '\{\{' => '{{', '\{\%' => '{%')
 
       # Gather settings
       site = context.registers[:site]
       settings = site.config['image']
-      markup = /^(?:(?<preset>[^\s.:\/]+)\s+)?(?<image_src>[^\s]+\.[a-zA-Z0-9]{3,4})\s*(?<html_attr>[\s\S]+)?$/.match(@markup)
+      markup = /^(?:(?<preset>[^\s.:\/]+)\s+)?(?<image_src>[^\s]+\.[a-zA-Z0-9]{3,4})\s*(?<html_attr>[\s\S]+)?$/.match(@instancemarkup)
       preset = settings['presets'][ markup[:preset] ]
 
       raise "Image Tag can't read this tag. Try {% image [preset or WxH] path/to/img.jpg [attr=\"value\"] %}." unless markup


### PR DESCRIPTION
...@markup when using the tag in a loop
