### PR TITLE
Generate file in source, then add to copy queue

### DIFF
--- a/image_tag.rb
+++ b/image_tag.rb
@@ -45,9 +45,6 @@ module Jekyll
       settings['source'] ||= '.'
       settings['output'] ||= 'generated'
 
-      # Prevent Jekyll from erasing our generated files
-      site.config['keep_files'] << settings['output'] unless site.config['keep_files'].include?(settings['output'])
-
       # Process instance
       instance = if preset
         {
@@ -88,13 +85,13 @@ module Jekyll
       raise "Image Tag can't find the \"#{markup[:preset]}\" preset. Check image: presets in _config.yml for a list of presets." unless preset || dim ||  markup[:preset].nil?
 
       # Generate resized images
-      generated_src = generate_image(instance, site.source, site.dest, settings['source'], settings['output'])
+      generated_src = generate_image(instance, site.source, site.dest, settings['source'], settings['output'], site)
 
       # Return the markup!
       "<img src=\"#{generated_src}\" #{html_attr_string}>"
     end
 
-    def generate_image(instance, site_source, site_dest, image_source, image_dest)
+    def generate_image(instance, site_source, site_dest, image_source, image_dest, site)
 
       image = MiniMagick::Image.open(File.join(site_source, image_source, instance[:src]))
       digest = Digest::MD5.hexdigest(image.to_blob).slice!(0..5)
@@ -131,8 +128,10 @@ module Jekyll
       end
 
       gen_name = "#{basename}-#{gen_width.round}x#{gen_height.round}-#{digest}#{ext}"
-      gen_dest_dir = File.join(site_dest, image_dest, image_dir)
+      gen_dest_dir = File.join(site_source, image_dest, image_dir)
       gen_dest_file = File.join(gen_dest_dir, gen_name)
+
+      site.static_files << Jekyll::StaticFile.new(site, site.source, image_dest, gen_name)
 
       # Generate resized files
       unless File.exists?(gen_dest_file)

--- a/image_tag.rb
+++ b/image_tag.rb
@@ -131,6 +131,13 @@ module Jekyll
       gen_dest_dir = File.join(site_source, image_dest, image_dir)
       gen_dest_file = File.join(gen_dest_dir, gen_name)
 
+      if instance[:src].include?("/")
+        gen_path = instance[:src].split('/')
+        gen_path.pop
+        gen_path = gen_path.join('/')
+        gen_name = gen_path + '/' + gen_name
+      end
+
       site.static_files << Jekyll::StaticFile.new(site, site.source, image_dest, gen_name)
 
       # Generate resized files


### PR DESCRIPTION
I don't think generating files directly into the `_site` directory is the best way to go about this type of a plugin. It's better to generate the files in the source then add them to the queue so Jekyll copies them over.

You might want to edit a bit more as I just made only the edits required to make this work, but it seems to be less of a fight with how Jekyll is designed. I also was never able to get my destination to work as a subdirectory until making this change.
