### PR TITLE
Return just the URL if "url" attribute is passed

### DIFF
--- a/image_tag.rb
+++ b/image_tag.rb
@@ -90,8 +90,13 @@ module Jekyll
       # Generate resized images
       generated_src = generate_image(instance, site.source, site.dest, settings['source'], settings['output'])
 
-      # Return the markup!
-      "<img src=\"#{generated_src}\" #{html_attr_string}>"
+      if html_attr.include? 'url'
+        # Return the url!
+        return generated_src
+      else
+        # Return the markup!
+        return "<img src=\"#{generated_src}\" #{html_attr_string}>"
+      end
     end
 
     def generate_image(instance, site_source, site_dest, image_source, image_dest)


### PR DESCRIPTION
`{% image 100x100 image.jpg %}` returns the `<img>` tag as usual

`{% image 100x100 image.jpg url %}` returns the just the url to the image.
