### PR TITLE
Allow images' URLs to be prefixed with anything

### DIFF
--- a/image_tag.rb
+++ b/image_tag.rb
@@ -89,6 +89,11 @@ module Jekyll
 
       # Generate resized images
       generated_src = generate_image(instance, site.source, site.dest, settings['source'], settings['output'])
+      
+      # Add url prefix if defined. The prefix should be without trailing slash
+      if settings['url_prefix']
+        generated_src = settings['url_prefix'] + generated_src.to_s
+      end
 
       # Return the markup!
       "<img src=\"#{generated_src}\" #{html_attr_string}>"


### PR DESCRIPTION
This will allow pulling images from a different domain, like requested in #11

Just define the prefix in `_config.yml` like this, without a trailing slash:

``` yaml
image:
  source: assets/images
  output: assets/images
  url_prefix: http://yoursecondarydomain.com
```
