### PR TITLE
Add site.baseurl to generated_src, if it is set

### DIFF
--- a/image_tag.rb
+++ b/image_tag.rb
@@ -93,6 +93,7 @@ module Jekyll
         return
       end
 
+      generated_src = File.join(site.baseurl, generated_src) unless site.baseurl.empty?
       # Return the markup!
       "<img src=\"#{generated_src}\" #{html_attr_string}>"
     end


### PR DESCRIPTION
I noticed, that the plugin will not generate the correct image paths if site.baseurl is set. This patch fixes this.
